### PR TITLE
Menu refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ dmypy.json
 
 # personal surister (pycharm)
 *.idea
+
+# OS X fluff
+.DS_Store

--- a/sportsBook.py
+++ b/sportsBook.py
@@ -1,0 +1,111 @@
+from footballMenu import football_menu
+from commonFunctions import is_number
+import argparse
+from sys import exit
+
+__author__ = "David Bristoll"
+__copyright__ = "Copyright 2018, David Bristoll"
+__maintainer__ = "David Bristoll"
+__email__ = "david.bristoll@gmail.com"
+__status__ = "Development"
+
+
+class MainMenu(object):
+    """
+    Main menu class object. Takes user input and moves onto the next menu.
+    """
+    def __init__(self):
+
+        self.parse_args()
+
+    def tennis(self):
+        """
+        Placeholder for Tennis selection.
+        Serves no function except for menu testing.
+        """
+        print("The tennis option is a placeholder for testing.")
+        print("The option is not supported in this build. \n\n")
+
+    def football(self):
+        """
+        Just calls the imported football_menu() function, so that if this
+        functionality changes in future it's easy to change once
+        rather than repeating ourselves throughout the code.
+        """
+
+        league_data = {}
+        fixtures = []
+        predictions = []
+
+        football_menu(league_data, fixtures, predictions)
+
+    def parse_args(self):
+        """"
+        Parses the command line arguments, so that power-users can
+        skip the menus. Currently very bare-bones.
+        """
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '-s', '--sport', help="The sport you wish to analyse.")
+
+        self.args = parser.parse_args()
+
+    def display_menu(self):
+        """
+        Main menu function
+        Offers all options in the options list.
+        Returns the selected function to run.
+        """
+        options = {
+            1: "Football",
+            2: "Tennis",
+        }
+        # If the user picked a sport by CLI argument, skip the main menu.
+        # This should be refactored to use the options dict, probably.
+        if self.args.sport:
+            if self.args.sport == "football":
+                self.football()
+            elif self.args.sport == "tennis":
+                self.tennis()
+            else:
+                print("{} is not currently a supported sport."
+                      .format(self.args.sport))
+                return
+
+        print("Welcome to SportsBook - A sports analysis tool.")
+        while True:
+            print("Main Menu")
+            print("---------")
+            print("Please select from one of the following sports:")
+            # Display all options
+            for key in options:
+                print("{}) {}".format(key, options[key]))
+            print("q) Quit")
+            # Take user selection
+            while True:
+                selected = input("Enter option: ")
+                # Quit option
+                if selected.lower() == "q":
+                    exit()
+                # If a number has been entered,
+                # convert the string to an integer.
+                try:
+                    selected = int(selected)
+                except ValueError:
+                    break
+                # If selected is a number,
+                # check to see if it is a valid key.
+                try:
+                    if options[selected] == "Football":
+                        self.football()
+                    elif options[selected] == "Tennis":
+                        self.tennis()
+                except KeyError:
+                    # If it's not valid, go back to the beginning.
+                    break
+                # If we got this far, go back to the beginning.
+                break
+
+
+mainmenu = MainMenu()
+mainmenu.display_menu()

--- a/sportsBook.py
+++ b/sportsBook.py
@@ -67,8 +67,7 @@ class MainMenu(object):
             elif self.args.sport == "tennis":
                 self.tennis()
             else:
-                print("{} is not currently a supported sport."
-                      .format(self.args.sport))
+                print(f"{self.args.sport} is not currently a supported sport.")
                 return
 
         print("Welcome to SportsBook - A sports analysis tool.")
@@ -78,7 +77,7 @@ class MainMenu(object):
             print("Please select from one of the following sports:")
             # Display all options
             for key in options:
-                print("{}) {}".format(key, options[key]))
+                print(f"{key}) {options[key]}")
             print("q) Quit")
             # Take user selection
             while True:

--- a/sportsBook.py
+++ b/sportsBook.py
@@ -1,5 +1,4 @@
 from footballMenu import football_menu
-from commonFunctions import is_number
 import argparse
 from sys import exit
 


### PR DESCRIPTION
- Made the main menu into a class object with methods.
- Ran Yapf over the file and shortened some comments, so the interpreter no longer gives warnings about non-standard code.
- Added basic argument parsing, so user can choose the sport from the CLI
- Modified .gitignore to ignore macOS system files.
- Made these code changes in the Experimental branch, where they're meant to be!

In future, I think it's probably best to keep all menu logic inside a single class, rather than calling menu functions in another file. That way, much easier to test, and to keep UI feel consistent between different parts of the program.