### PR TITLE
Better error handling when site is down

### DIFF
--- a/src/football.py
+++ b/src/football.py
@@ -132,8 +132,8 @@ def get_league_data(selection, league_data, fixtures):
     web_client = uReq(full_url)
 
     if web_client.getcode() != 200:
-        print("Cannot retrieve data, webpage is down")
-        return
+        print("\nCannot retrieve data, webpage is down")
+        return "Scrape error"
     web_html = web_client.read()
     web_client.close()
     web_soup = soup(web_html, "html.parser")
@@ -148,8 +148,8 @@ def get_league_data(selection, league_data, fixtures):
         except:
             # If no teams have yet been added, there is an error.
             if team_count == 0:
-                print("Web page error - Check link integrity and website status.")
-                return
+                print("\n" + selection + "\nWeb page error - Check url integrity and website status.")
+                return "Scrape error"
             # If teams have been added, the loop has reached the end of the table
             else:
                 break
@@ -412,8 +412,9 @@ def manual_game_analysis(league_data, predictions):
     if league_data == {}:
         print("You can't run manual game analysis until you have selected the appropriate league(s).")
         print("Please select a league or import a JSON file first.")
-        input("Press enter to continue")
-        return False
+        input("\nPress enter to continue")
+        error = "No leagues loaded" # Response advising why the function failed.
+        return error
 
     # Build the basic team list (this must be kept for later use)
     for team in list_teams(league_data):

--- a/src/footballMenu.py
+++ b/src/footballMenu.py
@@ -196,10 +196,19 @@ def football_menu(league_data, fixtures, predictions):
                 while not exit_manual_analysis_menu:
                     selection = ""
                     another_game = ""
-                    fb.manual_game_analysis(league_data, predictions)
+                    
+                    # Manual_predictions holds an error message if something goes wrong.
+                    manual_predictions = fb.manual_game_analysis(league_data, predictions) 
                     while another_game.lower() != "y" and another_game.lower() != "n":
-                        print("\nAnalyse another game? (Y/N)")
-                        another_game = input()
+                    
+                        # If something went wrong, don't ask to run another game analysis.
+                        print(manual_predictions)
+                        if manual_predictions == "No leagues loaded":
+                            exit_manual_analysis_menu = True
+                            break
+                        else:
+                            print("\nAnalyse another game? (Y/N)")
+                            another_game = input()
                         if another_game.lower() == "n":
                             exit_manual_analysis_menu = True
                             break


### PR DESCRIPTION
When the betstudy site is down, a response is still provided. This means that typical error catching methods don't work. The last update saw a catch for this type of error, but, as the site was up and running I was unable to test it.

It's down again today so I've tweaked and tided the displayed messaged. I've also prevented the manual game analysis option from asking if you'd like to analyse another game when it failed on the previous attempt due to no league information being available.