### PR TITLE
Benchmark game threshold for predictions, bug fix, tidying

### DIFF
--- a/src/commonFunctions.py
+++ b/src/commonFunctions.py
@@ -1,7 +1,6 @@
 # Useful functions
 from prettytable import PrettyTable
 import json
-import pandas as pd
 
 def remove_duplicates(old_list):
     """

--- a/src/footballMenu.py
+++ b/src/footballMenu.py
@@ -511,12 +511,12 @@ def football_menu(football_data):
                             ["(2) Generate predictions on currently loaded fixtures", "2"],
                             ["(3) Single game visual analysis from fixture list", "3", select_fixture],
                             ["(4) Single game benchmark result analysis", "4", benchmark],
-                            ["(5) Manual single game analysis", "4", fb.manual_game_analysis],
-                            ["(6) Reports", "5", reports],
-                            ["(7) Import data from JSON file", "6"],
-                            ["(8) Clear current prediction data", "7"],
-                            ["(9) Clear all data", "8"],
-                            ["(10) Change data source to " + next_data_source + " (CLEARS ALL DATA)", "9"],
+                            ["(5) Manual single game analysis", "5", fb.manual_game_analysis],
+                            ["(6) Reports", "6", reports],
+                            ["(7) Import data from JSON file", "7"],
+                            ["(8) Clear current prediction data", "8"],
+                            ["(9) Clear all data", "9"],
+                            ["(10) Change data source to " + next_data_source + " (CLEARS ALL DATA)", "10"],
                             ["(Q) Quit", "q", leave]
                             ]
         

--- a/src/predictiveAlgorithms.py
+++ b/src/predictiveAlgorithms.py
@@ -232,6 +232,10 @@ def upcoming_fixture_predictions_benchmarks(football_data):
     Returns the updated predictions list.
     """ 
     
+    # Optional - Don't add predictions where benchmark games are below threshold.
+    threshold = 3
+    avoid_below_threshold = True
+    
     for fixture in football_data["fixtures"]:
         fixture_league = fixture[0]
         fixture_datetime = fixture[1]
@@ -245,7 +249,10 @@ def upcoming_fixture_predictions_benchmarks(football_data):
         comaprison return notes:
         [H/A compare[Pld,W,D,L,F,A,Pts], Total compare[Pld,W,D,L,F,A,Pts]]
         """
-    
+        # Act on benchmark games threshold.
+        if avoid_below_threshold and benchmark_tables[2][home_team]["Played"] < threshold:
+            continue
+        
         home_team_max_goals = football_data["league_data"][fixture_league][home_team]["Home"]["For per Game"] * 2.5
         away_team_max_goals = football_data["league_data"][fixture_league][away_team]["Away"]["For per Game"] * 2.5
         


### PR DESCRIPTION
Fixed a bug which prevented some menu options from being selectable.
Removed the import of pandas in commonFunctions as it wasn't used.
Added a threshold of 3 games to the benchmark predictions.
  This means that, where teams haven't played matching opponents 3 or more times, a prediction won't be made.