### PR TITLE
Issue #90 fixed - Upgraded the is_number() function to accept spaces

### DIFF
--- a/src/commonFunctions.py
+++ b/src/commonFunctions.py
@@ -136,9 +136,9 @@ def is_number(s) -> bool:
     Returns True or False.
     """
     if isinstance(s, str):
+        s = s.strip()
         return s.isnumeric()
     return isinstance(s, int) or isinstance(s, float)
-
 
 def valid_input(selection, options) -> bool:
     """

--- a/src/football.py
+++ b/src/football.py
@@ -672,41 +672,42 @@ def prepare_prediction_dataframe(predictions):
     del temp_predictions
     return df
 
-def get_team_results(league, team_name, results, type="all"):
-	"""
+def get_team_results(league, team_name, results, mode="all"):
+    """
 	Takes a team name, set of results and a type (default type is "everything").
 	Sorts through all results and returns:
-	Type = "all": a list of [home_results, away_results, all_results] for that team.
-	Type = "total": all results for that team.
-	Type = "home and away": a list of [home_results, away_results] for that team.
-	Type = "home": home results for that team.
-	Type = "away": away results.
+	mode = "all": a list of [home_results, away_results, all_results] for that team.
+	mode = "total": all results for that team.
+	mode = "home and away": a list of [home_results, away_results] for that team.
+	mode = "home": home results for that team.
+	mode = "away": away results.
 	"""
-	if type == "total" or type == "home and away" or type == "all":
-		get = "total"
-	else:
-		get = type
-	home_results = []
-	away_results = []
-	total_results = []
-	for result in results:
-		if (get == "home" or get == "total") and result[0] == league and result[2] == team_name:
-			home_results.append(result)
-			total_results.append(result)
-		if (get == "away" or get == "total") and result[0] == league and result[4] == team_name:
-			away_results.append(result)
-			total_results.append(result)
+    if mode == "total" or mode == "home and away" or mode == "all":
+        get = "total"
+    else:
+        get = mode
+        
+    home_results = []
+    away_results = []
+    total_results = []
+    for result in results:
+        if (get == "home" or get == "total") and result[0] == league and result[2] == team_name:
+            home_results.append(result)
+            total_results.append(result)
+        if (get == "away" or get == "total") and result[0] == league and result[4] == team_name:
+            away_results.append(result)
+            total_results.append(result)
 
-	if type == "total":
-		return total_results
-	if type == "home and away":
-		return [home_results, away_results]
-	if type == "home":
-		return home_results
-	if type == "away":
-		return away_results
-	if type == "all":
-		return [home_results, away_results, total_results]
+    if mode == "total":
+        return total_results
+    if mode == "home and away":
+        return [home_results, away_results]
+    if mode == "home":
+        return home_results
+    if mode == "away":
+        return away_results
+    if mode == "all":
+        return [home_results, away_results, total_results]
 	
 def get_benchmarks(home_team_all_results, away_team_all_results):
     """
@@ -729,7 +730,13 @@ def get_benchmarks(home_team_all_results, away_team_all_results):
     P-P, as it would be for a postponed game.
     """
     for ht_result in home_team_all_results[0]:
+        
+        #print(ht_result) # DEBUG CODE
+        
         for at_result in away_team_all_results[0]:
+            
+            #print(at_result) # DEBUG CODE
+            
             if ht_result[4] == at_result[4] and cf.is_number(ht_result[3]) and cf.is_number(at_result[3]):
                 home_benchmarks.append([ht_result, at_result])
     """
@@ -770,9 +777,24 @@ def benchmark_analysis(fixture, football_data, display = True):
     #date_time = fixture[1]
     h_team = fixture[2]
     a_team = fixture[3]
-    h_results = get_team_results(league, h_team, football_data["results"], type = "all")
-    a_results = get_team_results(league, a_team, football_data["results"], type = "all")
+    h_results = get_team_results(league, h_team, football_data["results"], mode = "all")
+    
+    #print("HOME RESULTS") # DEBUG CODE
+    #print(h_results) # DEBUG CODE
+    #input() # DEBUG CODE
+    
+    a_results = get_team_results(league, a_team, football_data["results"], mode = "all")
+    
+    #print("AWAY RESULTS") # DEBUG CODE
+    #print(a_results) # DEBUG CODE
+    #input() # DEBUG CODE
+    
     benchmarks = get_benchmarks(h_results, a_results)
+    
+    #print("BENCHMARKS") # DEBUG CODE
+    #print(benchmarks) # DEBUG CODE
+    #input() # DEBUG CODE
+    
     """
     benchmarks structure: [
             [

--- a/src/predictiveAlgorithms.py
+++ b/src/predictiveAlgorithms.py
@@ -231,10 +231,11 @@ def upcoming_fixture_predictions_benchmarks(football_data):
     Adds each prediction to the predictions list.
     Returns the updated predictions list.
     """ 
-    
     # Optional - Don't add predictions where benchmark games are below threshold.
     threshold = 3
     avoid_below_threshold = True
+    
+    #print(football_data["fixtures"]) # DEBUG CODE
     
     for fixture in football_data["fixtures"]:
         fixture_league = fixture[0]
@@ -243,6 +244,8 @@ def upcoming_fixture_predictions_benchmarks(football_data):
         away_team = fixture[3]
         benchmark_tables = f.benchmark_analysis(fixture, football_data, display = False)
         #print("HOME TEAM: " + home_team + " AWAY TEAM: " + away_team) # DEBUG CODE
+        
+        #print(benchmark_tables) # DEBUG CODE
         
         #comparison = compare(homeTeam, awayTeam, league_data)
         """
@@ -281,6 +284,8 @@ def upcoming_fixture_predictions_benchmarks(football_data):
         "Home team prediction": home_team_goals, "Away team": away_team, "Away team prediction": away_team_goals, "Total goals expected": total_goals, 
         "Predicted separation": prediction_goal_separation, "Both to score": both_to_score, "date_as_dtobject": fixture[4]}
 
+        #print(prediction) # DEBUG CODE
+
         # Flatten league stats for prediction storage and exporting
         for team in [home_team, away_team]: # Do for each team
             if team == home_team:           # Used for the prediction keys
@@ -308,5 +313,8 @@ def upcoming_fixture_predictions_benchmarks(football_data):
         # If the prediction is not already in the predictions list, add it.
         if prediction not in football_data["predictions"]:
             football_data["predictions"].append(prediction)
+            
+        #print("PREDICTIONS:") # DEBUG CODE
         #print(football_data["predictions"]) # DEBUG CODE
+        
     return

--- a/src/scrapers.py
+++ b/src/scrapers.py
@@ -310,6 +310,8 @@ def get_league_data_bet_study(selection, league_data, fixtures, results, availab
                     away_score, # Away score
                     game_date] # Date as datetime object.
                 
+                #print(result) # DEBUG CODE
+                
                 # Only add the result to the results list if it's not already present.
                 if not result in results:
                     
@@ -320,9 +322,11 @@ def get_league_data_bet_study(selection, league_data, fixtures, results, availab
                         results.append(result[:]) # add result details to results.                    
             break
         except IndexError:
-            # Number of requested rsults exceeds the number of available results, break.
+            # Number of requested results exceeds the number of available results, break.
             break
 
+    #print(results) # DEBUG CODE
+    
     return "Success"
 
 def get_league_data_soccer_stats(selection, league_data, fixtures, results, available_leagues):
@@ -773,7 +777,7 @@ def get_league_data_soccer_stats(selection, league_data, fixtures, results, avai
                 else:
                     fixture = [selection, game_date_time.strftime("%d %b %Y %H:%M"), home_team, away_team, game_date_time]
                     # Only add the fixture to the fixtures list if it's not already present.
-                    if fixture not in fixtures:
+                    if fixture not in fixtures and fixture[4] >= today:
                         with fixtures_lock:
                             fixtures.append(fixture[:]) # add fixture details to fixtures
     # Not all results mode    


### PR DESCRIPTION
Fixed issue #90. The Bet Study scraper returning result scores as strings with spaces.
This was due to the is_number() function in commonFunctions.py not recognising strings containing only spaces and numbers as numbers. This has now been fixed.
Issue #84 showed its ugly face again. Finally fixed it 100%. The last fixed was only applied to one type of fixture that Soccer Stats provides. The scraper deals with two types and so some 'fixtures' with past dates were slipping through.